### PR TITLE
Add support for multiple authorized Telegram users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,23 @@ This plugin for [KOReader](https://github.com/koreader/koreader) allows you to s
 
 1) Download the plugin, unzip it in the `koreader/plugins` directory. This is the only step needed if you are updating plugin.
 2) Obtain a Telegram bot API token by contacting [@BotFather](https://t.me/botfather) bot, sending the `/newbot` command and following the steps until you're given a new token. You can find a step-by-step guide [here](https://core.telegram.org/bots/features#creating-a-new-bot).
-3) Get your Telegram user_ID with [@userinfobot](https://t.me/UserInfoToBot) telegram bot.
-4) Set your token and user_ID in the "Telegram Bot configuration" menu. Alternativly you can set them in the file `telegramdownloader.lua` in KOReader settings directory. This file is created automatically when plugin initialized. Insert following text with your API Token and user_id surrounded by quotes as shown it the example:
+3) Get the Telegram user IDs you want to authorize with [@userinfobot](https://t.me/UserInfoToBot) telegram bot.
+4) Set your token and comma-separated user IDs in the "Telegram Bot configuration" menu. Alternatively, you can set them in the file `telegramdownloader.lua` in the KOReader settings directory. This file is created automatically when the plugin is initialized. Insert the following text with your API token and authorized user IDs:
    
   ```lua
   return {
       ["token"] = "Insert your token here",
-      ["user_id"] = "12345",
+      ["user_ids"] = { 12345678, 87654321 },
   }
   ```
+
+  Existing configurations containing a single `user_id` continue to work.
 
 ## Usage
 
 1) You will find "TelegramDownloader" submenu item in the "tools" menu tab.
 2) Choose download folder.
-3) Send one or multiple files to your telegram bot. Telegram allows files up to 20MB.
+3) Send one or multiple files to your Telegram bot, either privately or from an authorized user in a private group containing the bot. Telegram allows files up to 20MB.
 4) Press "Download files" button in "TelegramDownloader" submenu.
 5) Wait for your files to be downloaded.
 
@@ -29,15 +31,17 @@ This plugin for [KOReader](https://github.com/koreader/koreader) allows you to s
 
 1) Скачайте архив в плагином и разархивируйте его в папку `koreader/plugins`. При обновлении плагина все остальные шаги не требуются.
 2) Для получения токена отправьте боту [@BotFather](https://t.me/botfather) сообщение `/newbot` и следуйте дальнейшим инструкциям. [Подробная иструкция.](https://core.telegram.org/bots/features#creating-a-new-bot)
-3) Узнайте свой Telegram user_id с помощью бота [@userinfobot](https://t.me/UserInfoToBot).
-4) Введите свой токен и user_id в меню "Telegram Bot configuration". Чтобы не вводить токен вручную, можно скопировать его в файл `telegramdownloader.lua` в папке koreader/setting. Этот файл создаётся автоматически при инициализации плагина. В файле укажите свой API токен и user_id в кавычках как показано в примере: 
+3) Узнайте Telegram user_id всех пользователей, которым нужен доступ, с помощью бота [@userinfobot](https://t.me/UserInfoToBot).
+4) Введите токен и разделённые запятыми user_id в меню "Telegram Bot configuration". Также их можно указать в файле `telegramdownloader.lua` в папке koreader/setting. Этот файл создаётся автоматически при инициализации плагина:
 
   ```lua
   return {
       ["token"] = "Insert your token here",
-      ["user_id"] = "12345",
+      ["user_ids"] = { 12345678, 87654321 },
   }
   ```
+
+  Существующие конфигурации с одним параметром `user_id` продолжают работать.
 
 ## Использование
 

--- a/main.lua
+++ b/main.lua
@@ -48,13 +48,67 @@ function TelegramDownloader:onTelegramDownloadFiles()
     return true
 end
 
+local function parseUserIds(value)
+    local user_ids = {}
+    local seen = {}
+    local is_valid = true
+
+    local function addUserId(user_id)
+        local text = tostring(user_id):match("^%s*(.-)%s*$")
+        if text == "" then
+            return
+        end
+
+        local id = text:match("^%d+$") and tonumber(text)
+        if not id or id <= 0 then
+            is_valid = false
+            return
+        end
+
+        if not seen[id] then
+            seen[id] = true
+            table.insert(user_ids, id)
+        end
+    end
+
+    if type(value) == "table" then
+        for _, user_id in ipairs(value) do
+            addUserId(user_id)
+        end
+    elseif value ~= nil then
+        for user_id in tostring(value):gmatch("[^,]+") do
+            addUserId(user_id)
+        end
+    end
+
+    return user_ids, is_valid
+end
+
 function TelegramDownloader:loadSettings()
     self.settings = LuaSettings:open(self.settings_file)
     self.directory = self.settings:readSetting("directory", DataStorage:getFullDataDir())
     self.offset = self.settings:readSetting("offset", 0)
     self.token = self.settings:readSetting("token", "")
-    self.user_id = self.settings:readSetting("user_id", "0")
+    local configured_user_ids = self.settings:readSetting("user_ids")
+    if configured_user_ids == nil then
+        configured_user_ids = self.settings:readSetting("user_id")
+    end
+    self.user_ids = parseUserIds(configured_user_ids)
     self.settings:close()
+end
+
+function TelegramDownloader:isUserAuthorized(user_id)
+    user_id = tonumber(user_id)
+    if not user_id then
+        return false
+    end
+
+    for _, authorized_id in ipairs(self.user_ids) do
+        if user_id == authorized_id then
+            return true
+        end
+    end
+    return false
 end
 
 function TelegramDownloader:getUpdates()
@@ -136,7 +190,8 @@ function TelegramDownloader:processUpdates(updates)
     local foundFiles = false
     
     for nouse, update in ipairs(updates.result) do
-        if update.message and update.message.document and update.message.from.id == tonumber(self.user_id) then
+        if update.message and update.message.document and update.message.from
+                and self:isUserAuthorized(update.message.from.id) then
             foundFiles = true
             local fileId = update.message.document.file_id
             local fileName = update.message.document.file_name
@@ -241,9 +296,9 @@ function TelegramDownloader:addToMainMenu(menu_items)
                                 hint = _("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"),
                             },
                             {
-                                description = _("Your user ID"),
-                                text = self.user_id,
-                                hint = _("12345678"),
+                                description = _("Authorized user IDs (comma-separated)"),
+                                text = table.concat(self.user_ids, ","),
+                                hint = _("12345678,87654321"),
                             },
                         },
                         buttons = {
@@ -267,10 +322,11 @@ function TelegramDownloader:addToMainMenu(menu_items)
                                     text = _("Save"),
                                     callback = function()
                                         local fields = configuration_window:getFields()
+                                        local user_ids, valid_user_ids = parseUserIds(fields[2])
 
-                                        if fields[1] ~= "" and tonumber(fields[2]) and tonumber(fields[2]) > 0 then
+                                        if fields[1] ~= "" and valid_user_ids and #user_ids > 0 then
                                             self.settings:saveSetting("token", fields[1])
-                                            self.settings:saveSetting("user_id", fields[2])
+                                            self.settings:saveSetting("user_ids", user_ids)
                                             self.settings:close()
 
                                             UIManager:show(InfoMessage:new{


### PR DESCRIPTION
## Summary

  This PR adds support for multiple authorized Telegram users instead of limiting the plugin to a single user_id.

  Authorized users can now be configured as a whitelist:

```
  user_ids = {
      12345678,
      87654321,
  }
```

  The configuration dialog accepts IDs as a comma-separated string:

  12345678,87654321

  ## Changes

  - Added support for a user_ids collection.
  - Added isUserAuthorized(user_id) to centralize authorization checks.
  - Replaced direct comparisons against self.user_id.
  - Added parsing and validation for comma-separated user IDs.
  - Empty values are ignored.
  - IDs are converted to numbers.
  - Duplicate IDs are removed.
  - Invalid and non-positive values are rejected.
  - Added backward compatibility with configurations containing only user_id.
  - Added a guard for Telegram messages without a from field.
  - Updated the README with the new configuration format.

  Authorization continues to use update.message.from.id instead of chat.id. This allows the plugin to work in private Telegram groups while ensuring that only whitelisted users can submit
  documents.

  ## Backward compatibility

  Existing configurations remain valid:

```
  return {
      ["token"] = "BOT_TOKEN",
      ["user_id"] = "12345678",
  }
```

  When user_ids is not present, the plugin automatically falls back to the legacy user_id setting.

  After saving through the updated configuration dialog, the new format is used:

```
  return {
      ["token"] = "BOT_TOKEN",
      ["user_ids"] = {
          12345678,
          87654321,
      },
  }
```

  ## Expected behavior

  - Authorized user A sends an EPUB: downloaded.
  - Authorized user B sends a PDF: downloaded.
  - Unauthorized user C sends a document: ignored.

  The same authorization behavior applies when the users and the bot are members of a private Telegram group.

  ## Validation

  The changes were validated with Lua 5.1 in a temporary Docker container:

  - main.lua passes luac5.1 -p.
  - Legacy user_id configurations load correctly.
  - Multiple IDs are parsed and authorized correctly.
  - Duplicate IDs are removed.
  - Empty entries are ignored.
  - Invalid and non-positive IDs are rejected.
  - Unauthorized users are ignored.
  - Messages without a from field are safely ignored.
  - Authorized documents from private and group chats are processed.
  - git diff --check passes.

  No changes were made to file downloads, destination folders, bot tokens, Telegram getUpdates, or offset handling.